### PR TITLE
fix: validator-manager - prevent crash when tx input can't be parsed

### DIFF
--- a/subgraphs/validator-manager/src/mapping.ts
+++ b/subgraphs/validator-manager/src/mapping.ts
@@ -68,7 +68,9 @@ export function handleInitiatedValidatorRegistration(
     dataToDecode
   );
 
-  entity.delegationFeeBips = decoded!.toTuple()[5].toBigInt();
+  entity.delegationFeeBips = decoded
+    ? decoded.toTuple()[5].toBigInt()
+    : new BigInt(10000);
 
   entity.save();
 }


### PR DESCRIPTION
prevent indexing error crashing  validator-manager subgraph when tx input can't be parsed
show 100% fees as fallback if it cant be determined otherwise

fixed error:
> Jun 06 07:42:38.183 ERRO Subgraph error 1/1, code: SubgraphSyncingFailure, error: transaction 5352c9c2029ee52889a64176ae8419339c51c12a0edb3e4c7ff6c26e438deafd: error while executing at wasm backtrace:      0: 0x3f43 - <unknown>!src/mapping/handleInitiatedValidatorRegistration: Mapping aborted at src/mapping.ts, line 71, column 30, with message: unexpected null in handler `handleInitiatedValidatorRegistration` at block #1395898 (f0a6c3ae0c3e367a344c4deb6e89a111c77a865ecf8d74f093a1895c621a2534), block_hash: 0xf0a6c3ae0c3e367a344c4deb6e89a111c77a865ecf8d74f093a1895c621a2534, block_number: 1395898, runner_index: 14, sgd: 597, subgraph_id: Qma2mJSYwdBb9rZqTAhYBG4HKAbrJnmWTUqygGSG8EDVWM, component: SubgraphInstanceManager

context:
> the error bubbles up here: https://github.com/BuildOnBeam/beam-subgraphs/blob/main/subgraphs/validator-manager/src/mapping.ts#L66
the subgraph expects the input-data of the function call to match a certain pattern - which doesn't seem to fit when the [tx](https://subnets-test.avax.network/beam/tx/0x5352c9c2029ee52889a64176ae8419339c51c12a0edb3e4c7ff6c26e438deafd?tab=details) is sent by safe. it has a lot more input params, and the arguments we're looking for are likely encoded into one of them, making parsing more difficult.
the good news is, it only needs this to save the validator's delegationFeeBips, so everything else should still work. however, the affected validator's delegation fee would be reported wrongly in the dashboard (eg 100%, or whatever value we want to use as a fallback)

