### PR TITLE
fix: weight deductions after claiming

### DIFF
--- a/subgraphs/validator-manager/abis/Native721TokenStakingManager.json
+++ b/subgraphs/validator-manager/abis/Native721TokenStakingManager.json
@@ -14,91 +14,49 @@
     "type": "function",
     "name": "BIPS_CONVERSION_FACTOR",
     "inputs": [],
-    "outputs": [
-      {
-        "name": "",
-        "type": "uint16",
-        "internalType": "uint16"
-      }
-    ],
+    "outputs": [{ "name": "", "type": "uint16", "internalType": "uint16" }],
     "stateMutability": "view"
   },
   {
     "type": "function",
     "name": "ERC721_STAKING_MANAGER_STORAGE_LOCATION",
     "inputs": [],
-    "outputs": [
-      {
-        "name": "",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
-    ],
+    "outputs": [{ "name": "", "type": "bytes32", "internalType": "bytes32" }],
     "stateMutability": "view"
   },
   {
     "type": "function",
     "name": "MAXIMUM_DELEGATION_FEE_BIPS",
     "inputs": [],
-    "outputs": [
-      {
-        "name": "",
-        "type": "uint16",
-        "internalType": "uint16"
-      }
-    ],
+    "outputs": [{ "name": "", "type": "uint16", "internalType": "uint16" }],
     "stateMutability": "view"
   },
   {
     "type": "function",
     "name": "P_CHAIN_BLOCKCHAIN_ID",
     "inputs": [],
-    "outputs": [
-      {
-        "name": "",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
-    ],
+    "outputs": [{ "name": "", "type": "bytes32", "internalType": "bytes32" }],
     "stateMutability": "view"
   },
   {
     "type": "function",
     "name": "REWARD_CLAIM_DELAY",
     "inputs": [],
-    "outputs": [
-      {
-        "name": "",
-        "type": "uint64",
-        "internalType": "uint64"
-      }
-    ],
+    "outputs": [{ "name": "", "type": "uint64", "internalType": "uint64" }],
     "stateMutability": "view"
   },
   {
     "type": "function",
     "name": "STAKING_MANAGER_STORAGE_LOCATION",
     "inputs": [],
-    "outputs": [
-      {
-        "name": "",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
-    ],
+    "outputs": [{ "name": "", "type": "bytes32", "internalType": "bytes32" }],
     "stateMutability": "view"
   },
   {
     "type": "function",
     "name": "UPTIME_REWARDS_THRESHOLD_PERCENTAGE",
     "inputs": [],
-    "outputs": [
-      {
-        "name": "",
-        "type": "uint8",
-        "internalType": "uint8"
-      }
-    ],
+    "outputs": [{ "name": "", "type": "uint8", "internalType": "uint8" }],
     "stateMutability": "view"
   },
   {
@@ -118,21 +76,9 @@
     "type": "function",
     "name": "cancelRewards",
     "inputs": [
-      {
-        "name": "primary",
-        "type": "bool",
-        "internalType": "bool"
-      },
-      {
-        "name": "epoch",
-        "type": "uint64",
-        "internalType": "uint64"
-      },
-      {
-        "name": "token",
-        "type": "address",
-        "internalType": "address"
-      }
+      { "name": "primary", "type": "bool", "internalType": "bool" },
+      { "name": "epoch", "type": "uint64", "internalType": "uint64" },
+      { "name": "token", "type": "address", "internalType": "address" }
     ],
     "outputs": [],
     "stateMutability": "nonpayable"
@@ -141,26 +87,10 @@
     "type": "function",
     "name": "claimRewards",
     "inputs": [
-      {
-        "name": "primary",
-        "type": "bool",
-        "internalType": "bool"
-      },
-      {
-        "name": "epoch",
-        "type": "uint64",
-        "internalType": "uint64"
-      },
-      {
-        "name": "tokens",
-        "type": "address[]",
-        "internalType": "address[]"
-      },
-      {
-        "name": "recipient",
-        "type": "address",
-        "internalType": "address"
-      }
+      { "name": "primary", "type": "bool", "internalType": "bool" },
+      { "name": "epoch", "type": "uint64", "internalType": "uint64" },
+      { "name": "tokens", "type": "address[]", "internalType": "address[]" },
+      { "name": "recipient", "type": "address", "internalType": "address" }
     ],
     "outputs": [],
     "stateMutability": "nonpayable"
@@ -169,16 +99,8 @@
     "type": "function",
     "name": "completeDelegatorRegistration",
     "inputs": [
-      {
-        "name": "delegationID",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      },
-      {
-        "name": "messageIndex",
-        "type": "uint32",
-        "internalType": "uint32"
-      }
+      { "name": "delegationID", "type": "bytes32", "internalType": "bytes32" },
+      { "name": "messageIndex", "type": "uint32", "internalType": "uint32" }
     ],
     "outputs": [],
     "stateMutability": "nonpayable"
@@ -187,16 +109,8 @@
     "type": "function",
     "name": "completeDelegatorRemoval",
     "inputs": [
-      {
-        "name": "delegationID",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      },
-      {
-        "name": "messageIndex",
-        "type": "uint32",
-        "internalType": "uint32"
-      }
+      { "name": "delegationID", "type": "bytes32", "internalType": "bytes32" },
+      { "name": "messageIndex", "type": "uint32", "internalType": "uint32" }
     ],
     "outputs": [],
     "stateMutability": "nonpayable"
@@ -205,11 +119,7 @@
     "type": "function",
     "name": "completeNFTDelegatorRemoval",
     "inputs": [
-      {
-        "name": "delegationID",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
+      { "name": "delegationID", "type": "bytes32", "internalType": "bytes32" }
     ],
     "outputs": [],
     "stateMutability": "nonpayable"
@@ -218,38 +128,18 @@
     "type": "function",
     "name": "completeValidatorRegistration",
     "inputs": [
-      {
-        "name": "messageIndex",
-        "type": "uint32",
-        "internalType": "uint32"
-      }
+      { "name": "messageIndex", "type": "uint32", "internalType": "uint32" }
     ],
-    "outputs": [
-      {
-        "name": "",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
-    ],
+    "outputs": [{ "name": "", "type": "bytes32", "internalType": "bytes32" }],
     "stateMutability": "nonpayable"
   },
   {
     "type": "function",
     "name": "completeValidatorRemoval",
     "inputs": [
-      {
-        "name": "messageIndex",
-        "type": "uint32",
-        "internalType": "uint32"
-      }
+      { "name": "messageIndex", "type": "uint32", "internalType": "uint32" }
     ],
-    "outputs": [
-      {
-        "name": "",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
-    ],
+    "outputs": [{ "name": "", "type": "bytes32", "internalType": "bytes32" }],
     "stateMutability": "nonpayable"
   },
   {
@@ -257,46 +147,27 @@
     "name": "erc721",
     "inputs": [],
     "outputs": [
-      {
-        "name": "",
-        "type": "address",
-        "internalType": "contract IERC721"
-      }
+      { "name": "", "type": "address", "internalType": "contract IERC721" }
     ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getEpoch",
+    "inputs": [],
+    "outputs": [{ "name": "", "type": "uint64", "internalType": "uint64" }],
     "stateMutability": "view"
   },
   {
     "type": "function",
     "name": "getRewards",
     "inputs": [
-      {
-        "name": "primary",
-        "type": "bool",
-        "internalType": "bool"
-      },
-      {
-        "name": "epoch",
-        "type": "uint64",
-        "internalType": "uint64"
-      },
-      {
-        "name": "tokens",
-        "type": "address[]",
-        "internalType": "address[]"
-      },
-      {
-        "name": "account",
-        "type": "address",
-        "internalType": "address"
-      }
+      { "name": "primary", "type": "bool", "internalType": "bool" },
+      { "name": "epoch", "type": "uint64", "internalType": "uint64" },
+      { "name": "token", "type": "address", "internalType": "address" },
+      { "name": "account", "type": "address", "internalType": "address" }
     ],
-    "outputs": [
-      {
-        "name": "",
-        "type": "uint256[]",
-        "internalType": "uint256[]"
-      }
-    ],
+    "outputs": [{ "name": "", "type": "uint256", "internalType": "uint256" }],
     "stateMutability": "view"
   },
   {
@@ -348,11 +219,7 @@
             "type": "uint256",
             "internalType": "uint256"
           },
-          {
-            "name": "validatorRemovalAdmin",
-            "type": "address",
-            "internalType": "address"
-          },
+          { "name": "admin", "type": "address", "internalType": "address" },
           {
             "name": "uptimeBlockchainID",
             "type": "bytes32",
@@ -367,7 +234,13 @@
             "name": "epochDuration",
             "type": "uint64",
             "internalType": "uint64"
-          }
+          },
+          {
+            "name": "uptimeKeeper",
+            "type": "address",
+            "internalType": "address"
+          },
+          { "name": "epochOffset", "type": "uint64", "internalType": "uint64" }
         ]
       },
       {
@@ -383,40 +256,18 @@
     "type": "function",
     "name": "initiateDelegatorRegistration",
     "inputs": [
-      {
-        "name": "validationID",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
+      { "name": "validationID", "type": "bytes32", "internalType": "bytes32" }
     ],
-    "outputs": [
-      {
-        "name": "",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
-    ],
+    "outputs": [{ "name": "", "type": "bytes32", "internalType": "bytes32" }],
     "stateMutability": "payable"
   },
   {
     "type": "function",
     "name": "initiateDelegatorRemoval",
     "inputs": [
-      {
-        "name": "delegationID",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      },
-      {
-        "name": "includeUptimeProof",
-        "type": "bool",
-        "internalType": "bool"
-      },
-      {
-        "name": "messageIndex",
-        "type": "uint32",
-        "internalType": "uint32"
-      }
+      { "name": "delegationID", "type": "bytes32", "internalType": "bytes32" },
+      { "name": "includeUptimeProof", "type": "bool", "internalType": "bool" },
+      { "name": "messageIndex", "type": "uint32", "internalType": "uint32" }
     ],
     "outputs": [],
     "stateMutability": "nonpayable"
@@ -425,11 +276,7 @@
     "type": "function",
     "name": "initiateNFTDelegatorRemoval",
     "inputs": [
-      {
-        "name": "delegationID",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
+      { "name": "delegationID", "type": "bytes32", "internalType": "bytes32" }
     ],
     "outputs": [],
     "stateMutability": "nonpayable"
@@ -438,40 +285,18 @@
     "type": "function",
     "name": "initiateRedelegation",
     "inputs": [
-      {
-        "name": "delegationID",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      },
-      {
-        "name": "validationID",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
+      { "name": "delegationID", "type": "bytes32", "internalType": "bytes32" },
+      { "name": "validationID", "type": "bytes32", "internalType": "bytes32" }
     ],
-    "outputs": [
-      {
-        "name": "",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
-    ],
+    "outputs": [{ "name": "", "type": "bytes32", "internalType": "bytes32" }],
     "stateMutability": "nonpayable"
   },
   {
     "type": "function",
     "name": "initiateValidatorRegistration",
     "inputs": [
-      {
-        "name": "nodeID",
-        "type": "bytes",
-        "internalType": "bytes"
-      },
-      {
-        "name": "blsPublicKey",
-        "type": "bytes",
-        "internalType": "bytes"
-      },
+      { "name": "nodeID", "type": "bytes", "internalType": "bytes" },
+      { "name": "blsPublicKey", "type": "bytes", "internalType": "bytes" },
       {
         "name": "registrationExpiry",
         "type": "uint64",
@@ -482,11 +307,7 @@
         "type": "tuple",
         "internalType": "struct PChainOwner",
         "components": [
-          {
-            "name": "threshold",
-            "type": "uint32",
-            "internalType": "uint32"
-          },
+          { "name": "threshold", "type": "uint32", "internalType": "uint32" },
           {
             "name": "addresses",
             "type": "address[]",
@@ -499,11 +320,7 @@
         "type": "tuple",
         "internalType": "struct PChainOwner",
         "components": [
-          {
-            "name": "threshold",
-            "type": "uint32",
-            "internalType": "uint32"
-          },
+          { "name": "threshold", "type": "uint32", "internalType": "uint32" },
           {
             "name": "addresses",
             "type": "address[]",
@@ -521,40 +338,18 @@
         "type": "uint64",
         "internalType": "uint64"
       },
-      {
-        "name": "tokenIDs",
-        "type": "uint256[]",
-        "internalType": "uint256[]"
-      }
+      { "name": "tokenIDs", "type": "uint256[]", "internalType": "uint256[]" }
     ],
-    "outputs": [
-      {
-        "name": "",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
-    ],
+    "outputs": [{ "name": "", "type": "bytes32", "internalType": "bytes32" }],
     "stateMutability": "payable"
   },
   {
     "type": "function",
     "name": "initiateValidatorRemoval",
     "inputs": [
-      {
-        "name": "validationID",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      },
-      {
-        "name": "includeUptimeProof",
-        "type": "bool",
-        "internalType": "bool"
-      },
-      {
-        "name": "messageIndex",
-        "type": "uint32",
-        "internalType": "uint32"
-      }
+      { "name": "validationID", "type": "bytes32", "internalType": "bytes32" },
+      { "name": "includeUptimeProof", "type": "bool", "internalType": "bool" },
+      { "name": "messageIndex", "type": "uint32", "internalType": "uint32" }
     ],
     "outputs": [],
     "stateMutability": "nonpayable"
@@ -563,82 +358,36 @@
     "type": "function",
     "name": "onERC721Received",
     "inputs": [
-      {
-        "name": "",
-        "type": "address",
-        "internalType": "address"
-      },
-      {
-        "name": "",
-        "type": "address",
-        "internalType": "address"
-      },
-      {
-        "name": "",
-        "type": "uint256",
-        "internalType": "uint256"
-      },
-      {
-        "name": "",
-        "type": "bytes",
-        "internalType": "bytes"
-      }
+      { "name": "", "type": "address", "internalType": "address" },
+      { "name": "", "type": "address", "internalType": "address" },
+      { "name": "", "type": "uint256", "internalType": "uint256" },
+      { "name": "", "type": "bytes", "internalType": "bytes" }
     ],
-    "outputs": [
-      {
-        "name": "",
-        "type": "bytes4",
-        "internalType": "bytes4"
-      }
-    ],
+    "outputs": [{ "name": "", "type": "bytes4", "internalType": "bytes4" }],
     "stateMutability": "nonpayable"
   },
   {
     "type": "function",
     "name": "owner",
     "inputs": [],
-    "outputs": [
-      {
-        "name": "",
-        "type": "address",
-        "internalType": "address"
-      }
-    ],
+    "outputs": [{ "name": "", "type": "address", "internalType": "address" }],
     "stateMutability": "view"
   },
   {
     "type": "function",
     "name": "registerNFTDelegation",
     "inputs": [
-      {
-        "name": "validationID",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      },
-      {
-        "name": "tokenIDs",
-        "type": "uint256[]",
-        "internalType": "uint256[]"
-      }
+      { "name": "validationID", "type": "bytes32", "internalType": "bytes32" },
+      { "name": "tokenIDs", "type": "uint256[]", "internalType": "uint256[]" }
     ],
-    "outputs": [
-      {
-        "name": "",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
-    ],
+    "outputs": [{ "name": "", "type": "bytes32", "internalType": "bytes32" }],
     "stateMutability": "nonpayable"
   },
   {
     "type": "function",
     "name": "registerNFTRedelegation",
     "inputs": [
-      {
-        "name": "delegationID",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      },
+      { "name": "delegationID", "type": "bytes32", "internalType": "bytes32" },
       {
         "name": "nextValidationID",
         "type": "bytes32",
@@ -652,26 +401,10 @@
     "type": "function",
     "name": "registerRewards",
     "inputs": [
-      {
-        "name": "primary",
-        "type": "bool",
-        "internalType": "bool"
-      },
-      {
-        "name": "epoch",
-        "type": "uint64",
-        "internalType": "uint64"
-      },
-      {
-        "name": "token",
-        "type": "address",
-        "internalType": "address"
-      },
-      {
-        "name": "amount",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
+      { "name": "primary", "type": "bool", "internalType": "bool" },
+      { "name": "epoch", "type": "uint64", "internalType": "uint64" },
+      { "name": "token", "type": "address", "internalType": "address" },
+      { "name": "amount", "type": "uint256", "internalType": "uint256" }
     ],
     "outputs": [],
     "stateMutability": "nonpayable"
@@ -687,11 +420,7 @@
     "type": "function",
     "name": "resendUpdateDelegator",
     "inputs": [
-      {
-        "name": "delegationID",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
+      { "name": "delegationID", "type": "bytes32", "internalType": "bytes32" }
     ],
     "outputs": [],
     "stateMutability": "nonpayable"
@@ -711,31 +440,10 @@
   },
   {
     "type": "function",
-    "name": "setEpochOffset",
-    "inputs": [
-      {
-        "name": "epochOffset",
-        "type": "uint64",
-        "internalType": "uint64"
-      }
-    ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
-  },
-  {
-    "type": "function",
     "name": "submitUptimeProof",
     "inputs": [
-      {
-        "name": "validationID",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      },
-      {
-        "name": "messageIndex",
-        "type": "uint32",
-        "internalType": "uint32"
-      }
+      { "name": "validationID", "type": "bytes32", "internalType": "bytes32" },
+      { "name": "messageIndex", "type": "uint32", "internalType": "uint32" }
     ],
     "outputs": [],
     "stateMutability": "nonpayable"
@@ -762,11 +470,7 @@
     "type": "function",
     "name": "transferOwnership",
     "inputs": [
-      {
-        "name": "newOwner",
-        "type": "address",
-        "internalType": "address"
-      }
+      { "name": "newOwner", "type": "address", "internalType": "address" }
     ],
     "outputs": [],
     "stateMutability": "nonpayable"
@@ -775,11 +479,7 @@
     "type": "function",
     "name": "unlockDelegator",
     "inputs": [
-      {
-        "name": "delegationID",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
+      { "name": "delegationID", "type": "bytes32", "internalType": "bytes32" }
     ],
     "outputs": [],
     "stateMutability": "nonpayable"
@@ -788,11 +488,7 @@
     "type": "function",
     "name": "unlockValidator",
     "inputs": [
-      {
-        "name": "validationID",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
+      { "name": "validationID", "type": "bytes32", "internalType": "bytes32" }
     ],
     "outputs": [],
     "stateMutability": "nonpayable"
@@ -801,38 +497,18 @@
     "type": "function",
     "name": "valueToWeight",
     "inputs": [
-      {
-        "name": "value",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
+      { "name": "value", "type": "uint256", "internalType": "uint256" }
     ],
-    "outputs": [
-      {
-        "name": "",
-        "type": "uint64",
-        "internalType": "uint64"
-      }
-    ],
+    "outputs": [{ "name": "", "type": "uint64", "internalType": "uint64" }],
     "stateMutability": "view"
   },
   {
     "type": "function",
     "name": "weightToValue",
     "inputs": [
-      {
-        "name": "weight",
-        "type": "uint64",
-        "internalType": "uint64"
-      }
+      { "name": "weight", "type": "uint64", "internalType": "uint64" }
     ],
-    "outputs": [
-      {
-        "name": "",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
-    ],
+    "outputs": [{ "name": "", "type": "uint256", "internalType": "uint256" }],
     "stateMutability": "view"
   },
   {
@@ -1177,18 +853,10 @@
     "type": "error",
     "name": "AddressInsufficientBalance",
     "inputs": [
-      {
-        "name": "account",
-        "type": "address",
-        "internalType": "address"
-      }
+      { "name": "account", "type": "address", "internalType": "address" }
     ]
   },
-  {
-    "type": "error",
-    "name": "FailedInnerCall",
-    "inputs": []
-  },
+  { "type": "error", "name": "FailedInnerCall", "inputs": [] },
   {
     "type": "error",
     "name": "InvalidDelegationFee",
@@ -1204,11 +872,7 @@
     "type": "error",
     "name": "InvalidDelegationID",
     "inputs": [
-      {
-        "name": "delegationID",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
+      { "name": "delegationID", "type": "bytes32", "internalType": "bytes32" }
     ]
   },
   {
@@ -1222,80 +886,46 @@
       }
     ]
   },
-  {
-    "type": "error",
-    "name": "InvalidInitialization",
-    "inputs": []
-  },
+  { "type": "error", "name": "InvalidInitialization", "inputs": [] },
   {
     "type": "error",
     "name": "InvalidInputLengths",
     "inputs": [
-      {
-        "name": "inputLength1",
-        "type": "uint256",
-        "internalType": "uint256"
-      },
-      {
-        "name": "inputLength2",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
+      { "name": "inputLength1", "type": "uint256", "internalType": "uint256" },
+      { "name": "inputLength2", "type": "uint256", "internalType": "uint256" }
     ]
   },
   {
     "type": "error",
     "name": "InvalidMinStakeDuration",
     "inputs": [
-      {
-        "name": "minStakeDuration",
-        "type": "uint64",
-        "internalType": "uint64"
-      }
+      { "name": "minStakeDuration", "type": "uint64", "internalType": "uint64" }
     ]
   },
   {
     "type": "error",
     "name": "InvalidNFTAmount",
     "inputs": [
-      {
-        "name": "nftAmount",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
+      { "name": "nftAmount", "type": "uint256", "internalType": "uint256" }
     ]
   },
   {
     "type": "error",
     "name": "InvalidNonce",
-    "inputs": [
-      {
-        "name": "nonce",
-        "type": "uint64",
-        "internalType": "uint64"
-      }
-    ]
+    "inputs": [{ "name": "nonce", "type": "uint64", "internalType": "uint64" }]
   },
   {
     "type": "error",
     "name": "InvalidStakeAmount",
     "inputs": [
-      {
-        "name": "stakeAmount",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
+      { "name": "stakeAmount", "type": "uint256", "internalType": "uint256" }
     ]
   },
   {
     "type": "error",
     "name": "InvalidTokenAddress",
     "inputs": [
-      {
-        "name": "tokenAddress",
-        "type": "address",
-        "internalType": "address"
-      }
+      { "name": "tokenAddress", "type": "address", "internalType": "address" }
     ]
   },
   {
@@ -1320,31 +950,19 @@
       }
     ]
   },
-  {
-    "type": "error",
-    "name": "InvalidWarpMessage",
-    "inputs": []
-  },
+  { "type": "error", "name": "InvalidWarpMessage", "inputs": [] },
   {
     "type": "error",
     "name": "InvalidWarpOriginSenderAddress",
     "inputs": [
-      {
-        "name": "senderAddress",
-        "type": "address",
-        "internalType": "address"
-      }
+      { "name": "senderAddress", "type": "address", "internalType": "address" }
     ]
   },
   {
     "type": "error",
     "name": "InvalidWarpSourceChainID",
     "inputs": [
-      {
-        "name": "sourceChainID",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
+      { "name": "sourceChainID", "type": "bytes32", "internalType": "bytes32" }
     ]
   },
   {
@@ -1362,108 +980,53 @@
     "type": "error",
     "name": "MinStakeDurationNotPassed",
     "inputs": [
-      {
-        "name": "endTime",
-        "type": "uint64",
-        "internalType": "uint64"
-      }
+      { "name": "endTime", "type": "uint64", "internalType": "uint64" }
     ]
   },
-  {
-    "type": "error",
-    "name": "NotInitializing",
-    "inputs": []
-  },
+  { "type": "error", "name": "NotInitializing", "inputs": [] },
   {
     "type": "error",
     "name": "OwnableInvalidOwner",
     "inputs": [
-      {
-        "name": "owner",
-        "type": "address",
-        "internalType": "address"
-      }
+      { "name": "owner", "type": "address", "internalType": "address" }
     ]
   },
   {
     "type": "error",
     "name": "OwnableUnauthorizedAccount",
     "inputs": [
-      {
-        "name": "account",
-        "type": "address",
-        "internalType": "address"
-      }
+      { "name": "account", "type": "address", "internalType": "address" }
     ]
   },
-  {
-    "type": "error",
-    "name": "ReentrancyGuardReentrantCall",
-    "inputs": []
-  },
+  { "type": "error", "name": "ReentrancyGuardReentrantCall", "inputs": [] },
   {
     "type": "error",
     "name": "TooEarly",
     "inputs": [
-      {
-        "name": "actualTime",
-        "type": "uint256",
-        "internalType": "uint256"
-      },
-      {
-        "name": "expectedTime",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
+      { "name": "actualTime", "type": "uint256", "internalType": "uint256" },
+      { "name": "expectedTime", "type": "uint256", "internalType": "uint256" }
     ]
   },
   {
     "type": "error",
     "name": "TooLate",
     "inputs": [
-      {
-        "name": "actualTime",
-        "type": "uint256",
-        "internalType": "uint256"
-      },
-      {
-        "name": "expectedTime",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
-    ]
-  },
-  {
-    "type": "error",
-    "name": "UnauthorizedInitialValidatorRemoval",
-    "inputs": [
-      {
-        "name": "sender",
-        "type": "address",
-        "internalType": "address"
-      }
+      { "name": "actualTime", "type": "uint256", "internalType": "uint256" },
+      { "name": "expectedTime", "type": "uint256", "internalType": "uint256" }
     ]
   },
   {
     "type": "error",
     "name": "UnauthorizedOwner",
     "inputs": [
-      {
-        "name": "sender",
-        "type": "address",
-        "internalType": "address"
-      }
+      { "name": "sender", "type": "address", "internalType": "address" }
     ]
   },
   {
     "type": "error",
     "name": "UnexpectedValidationID",
     "inputs": [
-      {
-        "name": "validationID",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      },
+      { "name": "validationID", "type": "bytes32", "internalType": "bytes32" },
       {
         "name": "expectedValidationID",
         "type": "bytes32",
@@ -1475,27 +1038,15 @@
     "type": "error",
     "name": "UnlockDurationNotPassed",
     "inputs": [
-      {
-        "name": "endTime",
-        "type": "uint64",
-        "internalType": "uint64"
-      }
+      { "name": "endTime", "type": "uint64", "internalType": "uint64" }
     ]
   },
   {
     "type": "error",
     "name": "ValidatorNotPoS",
     "inputs": [
-      {
-        "name": "validationID",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
+      { "name": "validationID", "type": "bytes32", "internalType": "bytes32" }
     ]
   },
-  {
-    "type": "error",
-    "name": "ZeroWeightToValueFactor",
-    "inputs": []
-  }
+  { "type": "error", "name": "ZeroWeightToValueFactor", "inputs": [] }
 ]

--- a/subgraphs/validator-manager/abis/ValidatorManager.json
+++ b/subgraphs/validator-manager/abis/ValidatorManager.json
@@ -14,91 +14,49 @@
     "type": "function",
     "name": "ADDRESS_LENGTH",
     "inputs": [],
-    "outputs": [
-      {
-        "name": "",
-        "type": "uint32",
-        "internalType": "uint32"
-      }
-    ],
+    "outputs": [{ "name": "", "type": "uint32", "internalType": "uint32" }],
     "stateMutability": "view"
   },
   {
     "type": "function",
     "name": "BLS_PUBLIC_KEY_LENGTH",
     "inputs": [],
-    "outputs": [
-      {
-        "name": "",
-        "type": "uint8",
-        "internalType": "uint8"
-      }
-    ],
+    "outputs": [{ "name": "", "type": "uint8", "internalType": "uint8" }],
     "stateMutability": "view"
   },
   {
     "type": "function",
     "name": "MAXIMUM_CHURN_PERCENTAGE_LIMIT",
     "inputs": [],
-    "outputs": [
-      {
-        "name": "",
-        "type": "uint8",
-        "internalType": "uint8"
-      }
-    ],
+    "outputs": [{ "name": "", "type": "uint8", "internalType": "uint8" }],
     "stateMutability": "view"
   },
   {
     "type": "function",
     "name": "MAXIMUM_REGISTRATION_EXPIRY_LENGTH",
     "inputs": [],
-    "outputs": [
-      {
-        "name": "",
-        "type": "uint64",
-        "internalType": "uint64"
-      }
-    ],
+    "outputs": [{ "name": "", "type": "uint64", "internalType": "uint64" }],
     "stateMutability": "view"
   },
   {
     "type": "function",
     "name": "NODE_ID_LENGTH",
     "inputs": [],
-    "outputs": [
-      {
-        "name": "",
-        "type": "uint32",
-        "internalType": "uint32"
-      }
-    ],
+    "outputs": [{ "name": "", "type": "uint32", "internalType": "uint32" }],
     "stateMutability": "view"
   },
   {
     "type": "function",
     "name": "P_CHAIN_BLOCKCHAIN_ID",
     "inputs": [],
-    "outputs": [
-      {
-        "name": "",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
-    ],
+    "outputs": [{ "name": "", "type": "bytes32", "internalType": "bytes32" }],
     "stateMutability": "view"
   },
   {
     "type": "function",
     "name": "VALIDATOR_MANAGER_STORAGE_LOCATION",
     "inputs": [],
-    "outputs": [
-      {
-        "name": "",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
-    ],
+    "outputs": [{ "name": "", "type": "bytes32", "internalType": "bytes32" }],
     "stateMutability": "view"
   },
   {
@@ -118,61 +76,29 @@
     "type": "function",
     "name": "completeValidatorRegistration",
     "inputs": [
-      {
-        "name": "messageIndex",
-        "type": "uint32",
-        "internalType": "uint32"
-      }
+      { "name": "messageIndex", "type": "uint32", "internalType": "uint32" }
     ],
-    "outputs": [
-      {
-        "name": "",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
-    ],
+    "outputs": [{ "name": "", "type": "bytes32", "internalType": "bytes32" }],
     "stateMutability": "nonpayable"
   },
   {
     "type": "function",
     "name": "completeValidatorRemoval",
     "inputs": [
-      {
-        "name": "messageIndex",
-        "type": "uint32",
-        "internalType": "uint32"
-      }
+      { "name": "messageIndex", "type": "uint32", "internalType": "uint32" }
     ],
-    "outputs": [
-      {
-        "name": "",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
-    ],
+    "outputs": [{ "name": "", "type": "bytes32", "internalType": "bytes32" }],
     "stateMutability": "nonpayable"
   },
   {
     "type": "function",
     "name": "completeValidatorWeightUpdate",
     "inputs": [
-      {
-        "name": "messageIndex",
-        "type": "uint32",
-        "internalType": "uint32"
-      }
+      { "name": "messageIndex", "type": "uint32", "internalType": "uint32" }
     ],
     "outputs": [
-      {
-        "name": "",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      },
-      {
-        "name": "",
-        "type": "uint64",
-        "internalType": "uint64"
-      }
+      { "name": "", "type": "bytes32", "internalType": "bytes32" },
+      { "name": "", "type": "uint64", "internalType": "uint64" }
     ],
     "stateMutability": "nonpayable"
   },
@@ -180,24 +106,14 @@
     "type": "function",
     "name": "getChurnPeriodSeconds",
     "inputs": [],
-    "outputs": [
-      {
-        "name": "",
-        "type": "uint64",
-        "internalType": "uint64"
-      }
-    ],
+    "outputs": [{ "name": "", "type": "uint64", "internalType": "uint64" }],
     "stateMutability": "view"
   },
   {
     "type": "function",
     "name": "getValidator",
     "inputs": [
-      {
-        "name": "validationID",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
+      { "name": "validationID", "type": "bytes32", "internalType": "bytes32" }
     ],
     "outputs": [
       {
@@ -210,41 +126,21 @@
             "type": "uint8",
             "internalType": "enum ValidatorStatus"
           },
-          {
-            "name": "nodeID",
-            "type": "bytes",
-            "internalType": "bytes"
-          },
+          { "name": "nodeID", "type": "bytes", "internalType": "bytes" },
           {
             "name": "startingWeight",
             "type": "uint64",
             "internalType": "uint64"
           },
-          {
-            "name": "sentNonce",
-            "type": "uint64",
-            "internalType": "uint64"
-          },
+          { "name": "sentNonce", "type": "uint64", "internalType": "uint64" },
           {
             "name": "receivedNonce",
             "type": "uint64",
             "internalType": "uint64"
           },
-          {
-            "name": "weight",
-            "type": "uint64",
-            "internalType": "uint64"
-          },
-          {
-            "name": "startTime",
-            "type": "uint64",
-            "internalType": "uint64"
-          },
-          {
-            "name": "endTime",
-            "type": "uint64",
-            "internalType": "uint64"
-          }
+          { "name": "weight", "type": "uint64", "internalType": "uint64" },
+          { "name": "startTime", "type": "uint64", "internalType": "uint64" },
+          { "name": "endTime", "type": "uint64", "internalType": "uint64" }
         ]
       }
     ],
@@ -259,16 +155,8 @@
         "type": "tuple",
         "internalType": "struct ValidatorManagerSettings",
         "components": [
-          {
-            "name": "admin",
-            "type": "address",
-            "internalType": "address"
-          },
-          {
-            "name": "subnetID",
-            "type": "bytes32",
-            "internalType": "bytes32"
-          },
+          { "name": "admin", "type": "address", "internalType": "address" },
+          { "name": "subnetID", "type": "bytes32", "internalType": "bytes32" },
           {
             "name": "churnPeriodSeconds",
             "type": "uint64",
@@ -294,11 +182,7 @@
         "type": "tuple",
         "internalType": "struct ConversionData",
         "components": [
-          {
-            "name": "subnetID",
-            "type": "bytes32",
-            "internalType": "bytes32"
-          },
+          { "name": "subnetID", "type": "bytes32", "internalType": "bytes32" },
           {
             "name": "validatorManagerBlockchainID",
             "type": "bytes32",
@@ -314,30 +198,18 @@
             "type": "tuple[]",
             "internalType": "struct InitialValidator[]",
             "components": [
-              {
-                "name": "nodeID",
-                "type": "bytes",
-                "internalType": "bytes"
-              },
+              { "name": "nodeID", "type": "bytes", "internalType": "bytes" },
               {
                 "name": "blsPublicKey",
                 "type": "bytes",
                 "internalType": "bytes"
               },
-              {
-                "name": "weight",
-                "type": "uint64",
-                "internalType": "uint64"
-              }
+              { "name": "weight", "type": "uint64", "internalType": "uint64" }
             ]
           }
         ]
       },
-      {
-        "name": "messageIndex",
-        "type": "uint32",
-        "internalType": "uint32"
-      }
+      { "name": "messageIndex", "type": "uint32", "internalType": "uint32" }
     ],
     "outputs": [],
     "stateMutability": "nonpayable"
@@ -346,16 +218,8 @@
     "type": "function",
     "name": "initiateValidatorRegistration",
     "inputs": [
-      {
-        "name": "nodeID",
-        "type": "bytes",
-        "internalType": "bytes"
-      },
-      {
-        "name": "blsPublicKey",
-        "type": "bytes",
-        "internalType": "bytes"
-      },
+      { "name": "nodeID", "type": "bytes", "internalType": "bytes" },
+      { "name": "blsPublicKey", "type": "bytes", "internalType": "bytes" },
       {
         "name": "registrationExpiry",
         "type": "uint64",
@@ -366,11 +230,7 @@
         "type": "tuple",
         "internalType": "struct PChainOwner",
         "components": [
-          {
-            "name": "threshold",
-            "type": "uint32",
-            "internalType": "uint32"
-          },
+          { "name": "threshold", "type": "uint32", "internalType": "uint32" },
           {
             "name": "addresses",
             "type": "address[]",
@@ -383,11 +243,7 @@
         "type": "tuple",
         "internalType": "struct PChainOwner",
         "components": [
-          {
-            "name": "threshold",
-            "type": "uint32",
-            "internalType": "uint32"
-          },
+          { "name": "threshold", "type": "uint32", "internalType": "uint32" },
           {
             "name": "addresses",
             "type": "address[]",
@@ -395,30 +251,16 @@
           }
         ]
       },
-      {
-        "name": "weight",
-        "type": "uint64",
-        "internalType": "uint64"
-      }
+      { "name": "weight", "type": "uint64", "internalType": "uint64" }
     ],
-    "outputs": [
-      {
-        "name": "",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
-    ],
+    "outputs": [{ "name": "", "type": "bytes32", "internalType": "bytes32" }],
     "stateMutability": "nonpayable"
   },
   {
     "type": "function",
     "name": "initiateValidatorRemoval",
     "inputs": [
-      {
-        "name": "validationID",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
+      { "name": "validationID", "type": "bytes32", "internalType": "bytes32" }
     ],
     "outputs": [],
     "stateMutability": "nonpayable"
@@ -427,28 +269,12 @@
     "type": "function",
     "name": "initiateValidatorWeightUpdate",
     "inputs": [
-      {
-        "name": "validationID",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      },
-      {
-        "name": "newWeight",
-        "type": "uint64",
-        "internalType": "uint64"
-      }
+      { "name": "validationID", "type": "bytes32", "internalType": "bytes32" },
+      { "name": "newWeight", "type": "uint64", "internalType": "uint64" }
     ],
     "outputs": [
-      {
-        "name": "",
-        "type": "uint64",
-        "internalType": "uint64"
-      },
-      {
-        "name": "",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
+      { "name": "", "type": "uint64", "internalType": "uint64" },
+      { "name": "", "type": "bytes32", "internalType": "bytes32" }
     ],
     "stateMutability": "nonpayable"
   },
@@ -456,45 +282,21 @@
     "type": "function",
     "name": "l1TotalWeight",
     "inputs": [],
-    "outputs": [
-      {
-        "name": "",
-        "type": "uint64",
-        "internalType": "uint64"
-      }
-    ],
+    "outputs": [{ "name": "", "type": "uint64", "internalType": "uint64" }],
     "stateMutability": "view"
   },
   {
     "type": "function",
     "name": "owner",
     "inputs": [],
-    "outputs": [
-      {
-        "name": "",
-        "type": "address",
-        "internalType": "address"
-      }
-    ],
+    "outputs": [{ "name": "", "type": "address", "internalType": "address" }],
     "stateMutability": "view"
   },
   {
     "type": "function",
     "name": "registeredValidators",
-    "inputs": [
-      {
-        "name": "nodeID",
-        "type": "bytes",
-        "internalType": "bytes"
-      }
-    ],
-    "outputs": [
-      {
-        "name": "",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
-    ],
+    "inputs": [{ "name": "nodeID", "type": "bytes", "internalType": "bytes" }],
+    "outputs": [{ "name": "", "type": "bytes32", "internalType": "bytes32" }],
     "stateMutability": "view"
   },
   {
@@ -508,11 +310,7 @@
     "type": "function",
     "name": "resendEndValidatorMessage",
     "inputs": [
-      {
-        "name": "validationID",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
+      { "name": "validationID", "type": "bytes32", "internalType": "bytes32" }
     ],
     "outputs": [],
     "stateMutability": "nonpayable"
@@ -521,11 +319,7 @@
     "type": "function",
     "name": "resendRegisterValidatorMessage",
     "inputs": [
-      {
-        "name": "validationID",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
+      { "name": "validationID", "type": "bytes32", "internalType": "bytes32" }
     ],
     "outputs": [],
     "stateMutability": "nonpayable"
@@ -534,24 +328,14 @@
     "type": "function",
     "name": "subnetID",
     "inputs": [],
-    "outputs": [
-      {
-        "name": "",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
-    ],
+    "outputs": [{ "name": "", "type": "bytes32", "internalType": "bytes32" }],
     "stateMutability": "view"
   },
   {
     "type": "function",
     "name": "transferOwnership",
     "inputs": [
-      {
-        "name": "newOwner",
-        "type": "address",
-        "internalType": "address"
-      }
+      { "name": "newOwner", "type": "address", "internalType": "address" }
     ],
     "outputs": [],
     "stateMutability": "nonpayable"
@@ -773,11 +557,7 @@
     "type": "error",
     "name": "InvalidBLSKeyLength",
     "inputs": [
-      {
-        "name": "length",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
+      { "name": "length", "type": "uint256", "internalType": "uint256" }
     ]
   },
   {
@@ -796,16 +576,8 @@
       }
     ]
   },
-  {
-    "type": "error",
-    "name": "InvalidInitialization",
-    "inputs": []
-  },
-  {
-    "type": "error",
-    "name": "InvalidInitializationStatus",
-    "inputs": []
-  },
+  { "type": "error", "name": "InvalidInitialization", "inputs": [] },
+  { "type": "error", "name": "InvalidInitializationStatus", "inputs": [] },
   {
     "type": "error",
     "name": "InvalidMaximumChurnPercentage",
@@ -820,34 +592,18 @@
   {
     "type": "error",
     "name": "InvalidNodeID",
-    "inputs": [
-      {
-        "name": "nodeID",
-        "type": "bytes",
-        "internalType": "bytes"
-      }
-    ]
+    "inputs": [{ "name": "nodeID", "type": "bytes", "internalType": "bytes" }]
   },
   {
     "type": "error",
     "name": "InvalidNonce",
-    "inputs": [
-      {
-        "name": "nonce",
-        "type": "uint64",
-        "internalType": "uint64"
-      }
-    ]
+    "inputs": [{ "name": "nonce", "type": "uint64", "internalType": "uint64" }]
   },
   {
     "type": "error",
     "name": "InvalidPChainOwnerThreshold",
     "inputs": [
-      {
-        "name": "threshold",
-        "type": "uint256",
-        "internalType": "uint256"
-      },
+      { "name": "threshold", "type": "uint256", "internalType": "uint256" },
       {
         "name": "addressesLength",
         "type": "uint256",
@@ -869,23 +625,13 @@
   {
     "type": "error",
     "name": "InvalidTotalWeight",
-    "inputs": [
-      {
-        "name": "weight",
-        "type": "uint64",
-        "internalType": "uint64"
-      }
-    ]
+    "inputs": [{ "name": "weight", "type": "uint64", "internalType": "uint64" }]
   },
   {
     "type": "error",
     "name": "InvalidValidationID",
     "inputs": [
-      {
-        "name": "validationID",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
+      { "name": "validationID", "type": "bytes32", "internalType": "bytes32" }
     ]
   },
   {
@@ -903,11 +649,7 @@
     "type": "error",
     "name": "InvalidValidatorManagerBlockchainID",
     "inputs": [
-      {
-        "name": "blockchainID",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
+      { "name": "blockchainID", "type": "bytes32", "internalType": "bytes32" }
     ]
   },
   {
@@ -921,107 +663,61 @@
       }
     ]
   },
-  {
-    "type": "error",
-    "name": "InvalidWarpMessage",
-    "inputs": []
-  },
+  { "type": "error", "name": "InvalidWarpMessage", "inputs": [] },
   {
     "type": "error",
     "name": "InvalidWarpOriginSenderAddress",
     "inputs": [
-      {
-        "name": "senderAddress",
-        "type": "address",
-        "internalType": "address"
-      }
+      { "name": "senderAddress", "type": "address", "internalType": "address" }
     ]
   },
   {
     "type": "error",
     "name": "InvalidWarpSourceChainID",
     "inputs": [
-      {
-        "name": "sourceChainID",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
+      { "name": "sourceChainID", "type": "bytes32", "internalType": "bytes32" }
     ]
   },
   {
     "type": "error",
     "name": "MaxChurnRateExceeded",
     "inputs": [
-      {
-        "name": "churnAmount",
-        "type": "uint64",
-        "internalType": "uint64"
-      }
+      { "name": "churnAmount", "type": "uint64", "internalType": "uint64" }
     ]
   },
   {
     "type": "error",
     "name": "NodeAlreadyRegistered",
-    "inputs": [
-      {
-        "name": "nodeID",
-        "type": "bytes",
-        "internalType": "bytes"
-      }
-    ]
+    "inputs": [{ "name": "nodeID", "type": "bytes", "internalType": "bytes" }]
   },
-  {
-    "type": "error",
-    "name": "NotInitializing",
-    "inputs": []
-  },
+  { "type": "error", "name": "NotInitializing", "inputs": [] },
   {
     "type": "error",
     "name": "OwnableInvalidOwner",
     "inputs": [
-      {
-        "name": "owner",
-        "type": "address",
-        "internalType": "address"
-      }
+      { "name": "owner", "type": "address", "internalType": "address" }
     ]
   },
   {
     "type": "error",
     "name": "OwnableUnauthorizedAccount",
     "inputs": [
-      {
-        "name": "account",
-        "type": "address",
-        "internalType": "address"
-      }
+      { "name": "account", "type": "address", "internalType": "address" }
     ]
   },
-  {
-    "type": "error",
-    "name": "PChainOwnerAddressesNotSorted",
-    "inputs": []
-  },
+  { "type": "error", "name": "PChainOwnerAddressesNotSorted", "inputs": [] },
   {
     "type": "error",
     "name": "UnauthorizedCaller",
     "inputs": [
-      {
-        "name": "caller",
-        "type": "address",
-        "internalType": "address"
-      }
+      { "name": "caller", "type": "address", "internalType": "address" }
     ]
   },
   {
     "type": "error",
     "name": "UnexpectedRegistrationStatus",
     "inputs": [
-      {
-        "name": "validRegistration",
-        "type": "bool",
-        "internalType": "bool"
-      }
+      { "name": "validRegistration", "type": "bool", "internalType": "bool" }
     ]
   }
 ]

--- a/subgraphs/validator-manager/src/mapping.ts
+++ b/subgraphs/validator-manager/src/mapping.ts
@@ -54,8 +54,26 @@ export function handleInitiatedValidatorRegistration(
   }
   entity.totalTokens = BigInt.fromI32(entity.tokenIDs!.length);
 
-  entity.delegationFeeBips = BigInt.fromI32(10000);
-  entity.minStakeDuration = BigInt.zero();
+  const inputDataHexString = event.transaction.input.toHexString().slice(10);
+  const hexStringToDecode =
+    "0x0000000000000000000000000000000000000000000000000000000000000020" +
+    inputDataHexString;
+  const dataToDecode = Bytes.fromByteArray(
+    Bytes.fromHexString(hexStringToDecode)
+  );
+
+  const decoded = ethereum.decode(
+    "(bytes,bytes,uint64,(uint32,address[]),(uint32,address[]),uint16,uint64,uint256[])",
+    dataToDecode
+  );
+
+  entity.delegationFeeBips = decoded
+    ? decoded.toTuple()[5].toBigInt()
+    : new BigInt(10000);
+
+  entity.minStakeDuration = decoded
+    ? decoded.toTuple()[6].toBigInt()
+    : BigInt.zero();
 
   entity.save();
 }
@@ -221,39 +239,33 @@ export function handleUnlockedDelegation(event: UnlockedDelegation): void {
   let delegation = getOrCreateDelegation(event.params.delegationID);
   let validation = getOrCreateValidation(delegation.validationID);
 
-  delegation.unlocked = true;
-
-  const isNFTDelegation =
-    delegation.tokenIDs != null && delegation.tokenIDs!.length > 0;
-
-  if (!isNFTDelegation) {
-    validation.weight = validation.weight.minus(delegation.weight);
-    validation.save();
+  if (!delegation.unlocked) {
+    const isNFT =
+      delegation.tokenIDs != null && delegation.tokenIDs!.length > 0;
+    if (!isNFT) {
+      validation.weight = validation.weight.minus(delegation.weight);
+      validation.save();
+    }
+    delegation.unlocked = true;
+    delegation.save();
   }
-
-  delegation.save();
 }
 
 export function handleUnlockedValidation(event: UnlockedValidation): void {
   let validation = getOrCreateValidation(event.params.validationID);
 
-  if (
-    !validation.unlocked &&
-    validation.tokenIDs != null &&
-    validation.tokenIDs!.length > 0
-  ) {
-    validation.totalTokens = validation.totalTokens.minus(
-      BigInt.fromI32(validation.tokenIDs!.length)
-    );
+  if (!validation.unlocked) {
+    if (validation.tokenIDs != null && validation.tokenIDs!.length > 0) {
+      validation.totalTokens = validation.totalTokens.minus(
+        BigInt.fromI32(validation.tokenIDs!.length)
+      );
+    }
 
-    // validation.tokenIDs = []; // uncomment if we want to clear self-staked list after claim
+    validation.weight = validation.weight.minus(validation.initialWeight);
+    validation.unlocked = true;
+    validation.save();
+    return;
   }
-
-  validation.unlocked = true;
-
-  validation.weight = validation.weight.minus(validation.initialWeight);
-
-  validation.save();
 }
 
 export function handleRewardClaimed(event: RewardClaimed): void {

--- a/subgraphs/validator-manager/src/mapping.ts
+++ b/subgraphs/validator-manager/src/mapping.ts
@@ -1,5 +1,3 @@
-// subgraphs/validator-manager/src/mapping.ts
-
 import {
   InitiatedValidatorRegistration,
   InitiatedValidatorRemoval,
@@ -31,10 +29,6 @@ import {
 } from "../generated/schema";
 import { Bytes, BigInt, Address, ethereum } from "@graphprotocol/graph-ts";
 
-// ----------------------
-// Validator lifecycle
-// ----------------------
-
 export function handleInitiatedValidatorRegistration(
   event: InitiatedValidatorRegistration
 ): void {
@@ -42,12 +36,11 @@ export function handleInitiatedValidatorRegistration(
 
   entity.nodeID = event.params.nodeID;
   entity.owner = event.transaction.from;
-  entity.weight = event.params.weight; // BEAM at registration
-  entity.initialWeight = event.params.weight; // snapshot of self BEAM at registration
+  entity.weight = event.params.weight;
+  entity.initialWeight = event.params.weight;
   entity.status = "PendingAdded";
   entity.initiateRegistrationTx = event.transaction.hash;
 
-  // === NFT logic (unchanged) ===
   for (let i = 0; i < event.receipt!.logs.length; i++) {
     const eventLog = event.receipt!.logs[i];
     if (
@@ -60,23 +53,9 @@ export function handleInitiatedValidatorRegistration(
     }
   }
   entity.totalTokens = BigInt.fromI32(entity.tokenIDs!.length);
-  // === /NFT logic ===
 
-  // Decode initiateValidatorRegistration args (no fake offset)
-  const paramsHex = event.transaction.input.toHexString().slice(10); // strip selector
-  const paramsBytes = Bytes.fromHexString(paramsHex);
-  const decoded = ethereum.decode(
-    "(bytes,bytes,uint64,(uint32,address[]),(uint32,address[]),uint16,uint64,uint256[])",
-    paramsBytes
-  );
-
-  entity.delegationFeeBips = decoded
-    ? decoded.toTuple()[5].toBigInt()
-    : BigInt.fromI32(10000);
-
-  entity.minStakeDuration = decoded
-    ? decoded.toTuple()[6].toBigInt()
-    : BigInt.zero();
+  entity.delegationFeeBips = BigInt.fromI32(10000);
+  entity.minStakeDuration = BigInt.zero();
 
   entity.save();
 }
@@ -138,12 +117,7 @@ export function handleCompletedValidatorWeightUpdate(
     entity.weight = event.params.weight;
     entity.save();
   }
-  // If event.params.weight < entity.weight, ignore here; subtract later at unlock.
 }
-
-// ----------------------
-// Delegation lifecycle
-// ----------------------
 
 export function handleInitiatedDelegatorRegistration(
   event: InitiatedDelegatorRegistration
@@ -154,7 +128,7 @@ export function handleInitiatedDelegatorRegistration(
   entity.validationID = validation.id;
   entity.validationNodeID = validation.nodeID;
   entity.owner = event.params.delegatorAddress;
-  entity.weight = event.params.delegatorWeight; // BEAM delegation weight (if BEAM)
+  entity.weight = event.params.delegatorWeight;
   entity.status = "PendingAdded";
   entity.initiateRegistrationTx = event.transaction.hash;
   entity.save();
@@ -180,11 +154,9 @@ export function handleInitiatedDelegatorRemoval(
   entity.status = "PendingRemoved";
   entity.initiateRemovalTx = event.transaction.hash;
 
-  // === NFT logic (unchanged) ===
   if (entity.tokenIDs != null) {
     entity.status = "Removed";
   }
-  // === /NFT logic ===
 
   entity.save();
 }
@@ -197,8 +169,7 @@ export function handleCompletedDelegatorRemoval(
   entity.status = "Removed";
   entity.completeRemovalTx = event.transaction.hash;
 
-  // === NFT logic (unchanged) ===
-  if (entity.tokenIDs != null) {
+  if (!entity.unlocked && entity.tokenIDs != null) {
     let validation = getOrCreateValidation(entity.validationID);
     validation.totalTokens = validation.totalTokens.minus(
       BigInt.fromI32(entity.tokenIDs!.length)
@@ -207,7 +178,6 @@ export function handleCompletedDelegatorRemoval(
 
     entity.unlocked = true;
   }
-  // === /NFT logic ===
 
   entity.save();
 }
@@ -218,18 +188,12 @@ export function handleDelegatedNFTs(event: DelegatedNFTs): void {
   entity.tokenIDs = event.params.tokenIDs;
   entity.save();
 
-  // === NFT logic (unchanged) ===
   let validation = getOrCreateValidation(entity.validationID);
   validation.totalTokens = validation.totalTokens.plus(
     BigInt.fromI32(event.params.tokenIDs.length)
   );
   validation.save();
-  // === /NFT logic ===
 }
-
-// ----------------------
-// Uptime & rewards
-// ----------------------
 
 export function handleUptimeUpdated(event: UptimeUpdated): void {
   let entity = UptimeUpdate.load(
@@ -253,22 +217,16 @@ export function handleRewardResolved(event: RewardResolved): void {
   entity.save();
 }
 
-// ----------------------
-// Unlocks (21-day complete + claimed)
-// ----------------------
-
 export function handleUnlockedDelegation(event: UnlockedDelegation): void {
   let delegation = getOrCreateDelegation(event.params.delegationID);
   let validation = getOrCreateValidation(delegation.validationID);
 
   delegation.unlocked = true;
 
-  // Only change BEAM weight here; keep ALL NFT behavior as-is elsewhere.
   const isNFTDelegation =
     delegation.tokenIDs != null && delegation.tokenIDs!.length > 0;
 
   if (!isNFTDelegation) {
-    // BEAM claim → reduce validator.weight by EXACT delegation.weight
     validation.weight = validation.weight.minus(delegation.weight);
     validation.save();
   }
@@ -279,18 +237,24 @@ export function handleUnlockedDelegation(event: UnlockedDelegation): void {
 export function handleUnlockedValidation(event: UnlockedValidation): void {
   let validation = getOrCreateValidation(event.params.validationID);
 
+  if (
+    !validation.unlocked &&
+    validation.tokenIDs != null &&
+    validation.tokenIDs!.length > 0
+  ) {
+    validation.totalTokens = validation.totalTokens.minus(
+      BigInt.fromI32(validation.tokenIDs!.length)
+    );
+
+    // validation.tokenIDs = []; // uncomment if we want to clear self-staked list after claim
+  }
+
   validation.unlocked = true;
 
-  // Only change BEAM weight here; DO NOT touch NFTs (keep original behavior).
-  // Reduce validator.weight by EXACT self-stake recorded at registration.
   validation.weight = validation.weight.minus(validation.initialWeight);
 
   validation.save();
 }
-
-// ----------------------
-// Reward claims snapshot
-// ----------------------
 
 export function handleRewardClaimed(event: RewardClaimed): void {
   let entity = getOrCreateClaimedReward(
@@ -368,10 +332,6 @@ export function handleRewardCancelled(event: RewardCancelled): void {
   entity.save();
 }
 
-// ----------------------
-// helpers
-// ----------------------
-
 function getOrCreateValidation(id: Bytes): Validation {
   let entity = Validation.load(id);
   if (entity == null) {
@@ -400,7 +360,6 @@ function getOrCreateDelegation(id: Bytes): Delegation {
     entity.status = "Unknown";
     entity.unlocked = false;
     entity.lastRewardedEpoch = BigInt.zero();
-    // Note: keep tokenIDs uninitialized as in original (nullable) behavior
   }
   return entity;
 }

--- a/subgraphs/validator-manager/src/mapping.ts
+++ b/subgraphs/validator-manager/src/mapping.ts
@@ -1,3 +1,5 @@
+// subgraphs/validator-manager/src/mapping.ts
+
 import {
   InitiatedValidatorRegistration,
   InitiatedValidatorRemoval,
@@ -29,6 +31,10 @@ import {
 } from "../generated/schema";
 import { Bytes, BigInt, Address, ethereum } from "@graphprotocol/graph-ts";
 
+// ----------------------
+// Validator lifecycle
+// ----------------------
+
 export function handleInitiatedValidatorRegistration(
   event: InitiatedValidatorRegistration
 ): void {
@@ -36,11 +42,12 @@ export function handleInitiatedValidatorRegistration(
 
   entity.nodeID = event.params.nodeID;
   entity.owner = event.transaction.from;
-  entity.weight = event.params.weight;
-  entity.initialWeight = event.params.weight;
+  entity.weight = event.params.weight; // BEAM at registration
+  entity.initialWeight = event.params.weight; // snapshot of self BEAM at registration
   entity.status = "PendingAdded";
   entity.initiateRegistrationTx = event.transaction.hash;
 
+  // === NFT logic (unchanged) ===
   for (let i = 0; i < event.receipt!.logs.length; i++) {
     const eventLog = event.receipt!.logs[i];
     if (
@@ -52,25 +59,20 @@ export function handleInitiatedValidatorRegistration(
       entity.tokenIDs = tokenIDs;
     }
   }
-
   entity.totalTokens = BigInt.fromI32(entity.tokenIDs!.length);
+  // === /NFT logic ===
 
-  const inputDataHexString = event.transaction.input.toHexString().slice(10);
-  const hexStringToDecode =
-    "0x0000000000000000000000000000000000000000000000000000000000000020" +
-    inputDataHexString;
-  const dataToDecode = Bytes.fromByteArray(
-    Bytes.fromHexString(hexStringToDecode)
-  );
-
+  // Decode initiateValidatorRegistration args (no fake offset)
+  const paramsHex = event.transaction.input.toHexString().slice(10); // strip selector
+  const paramsBytes = Bytes.fromHexString(paramsHex);
   const decoded = ethereum.decode(
     "(bytes,bytes,uint64,(uint32,address[]),(uint32,address[]),uint16,uint64,uint256[])",
-    dataToDecode
+    paramsBytes
   );
 
   entity.delegationFeeBips = decoded
     ? decoded.toTuple()[5].toBigInt()
-    : new BigInt(10000);
+    : BigInt.fromI32(10000);
 
   entity.minStakeDuration = decoded
     ? decoded.toTuple()[6].toBigInt()
@@ -98,6 +100,7 @@ export function handleRegisteredInitialValidator(
   entity.nodeID = event.params.nodeID;
   entity.owner = Address.zero();
   entity.weight = event.params.weight;
+  entity.initialWeight = event.params.weight;
   entity.startedAt = event.block.timestamp.toI64();
   entity.status = "Active";
   entity.save();
@@ -119,6 +122,7 @@ export function handleCompletedValidatorRemoval(
 ): void {
   let entity = getOrCreateValidation(event.params.validationID);
 
+  // No BEAM reductions here; we reduce only when unlock completes.
   entity.status = "Removed";
   entity.completeRemovalTx = event.transaction.hash;
   entity.save();
@@ -129,9 +133,17 @@ export function handleCompletedValidatorWeightUpdate(
 ): void {
   let entity = getOrCreateValidation(event.params.validationID);
 
-  entity.weight = event.params.weight;
-  entity.save();
+  // Apply only increases now; defer decreases until unlock/claim.
+  if (event.params.weight.gt(entity.weight)) {
+    entity.weight = event.params.weight;
+    entity.save();
+  }
+  // If event.params.weight < entity.weight, ignore here; subtract later at unlock.
 }
+
+// ----------------------
+// Delegation lifecycle
+// ----------------------
 
 export function handleInitiatedDelegatorRegistration(
   event: InitiatedDelegatorRegistration
@@ -142,7 +154,7 @@ export function handleInitiatedDelegatorRegistration(
   entity.validationID = validation.id;
   entity.validationNodeID = validation.nodeID;
   entity.owner = event.params.delegatorAddress;
-  entity.weight = event.params.delegatorWeight;
+  entity.weight = event.params.delegatorWeight; // BEAM delegation weight (if BEAM)
   entity.status = "PendingAdded";
   entity.initiateRegistrationTx = event.transaction.hash;
   entity.save();
@@ -168,9 +180,12 @@ export function handleInitiatedDelegatorRemoval(
   entity.status = "PendingRemoved";
   entity.initiateRemovalTx = event.transaction.hash;
 
+  // === NFT logic (unchanged) ===
   if (entity.tokenIDs != null) {
     entity.status = "Removed";
   }
+  // === /NFT logic ===
+
   entity.save();
 }
 
@@ -182,6 +197,7 @@ export function handleCompletedDelegatorRemoval(
   entity.status = "Removed";
   entity.completeRemovalTx = event.transaction.hash;
 
+  // === NFT logic (unchanged) ===
   if (entity.tokenIDs != null) {
     let validation = getOrCreateValidation(entity.validationID);
     validation.totalTokens = validation.totalTokens.minus(
@@ -191,6 +207,8 @@ export function handleCompletedDelegatorRemoval(
 
     entity.unlocked = true;
   }
+  // === /NFT logic ===
+
   entity.save();
 }
 
@@ -200,12 +218,18 @@ export function handleDelegatedNFTs(event: DelegatedNFTs): void {
   entity.tokenIDs = event.params.tokenIDs;
   entity.save();
 
+  // === NFT logic (unchanged) ===
   let validation = getOrCreateValidation(entity.validationID);
   validation.totalTokens = validation.totalTokens.plus(
     BigInt.fromI32(event.params.tokenIDs.length)
   );
   validation.save();
+  // === /NFT logic ===
 }
+
+// ----------------------
+// Uptime & rewards
+// ----------------------
 
 export function handleUptimeUpdated(event: UptimeUpdated): void {
   let entity = UptimeUpdate.load(
@@ -226,23 +250,47 @@ export function handleUptimeUpdated(event: UptimeUpdated): void {
 export function handleRewardResolved(event: RewardResolved): void {
   let entity = getOrCreateDelegation(event.params.delegationID);
   entity.lastRewardedEpoch = event.params.epoch;
-
   entity.save();
 }
 
-export function handleUnlockedDelegation(event: UnlockedDelegation): void {
-  let entity = getOrCreateDelegation(event.params.delegationID);
+// ----------------------
+// Unlocks (21-day complete + claimed)
+// ----------------------
 
-  entity.unlocked = true;
-  entity.save();
+export function handleUnlockedDelegation(event: UnlockedDelegation): void {
+  let delegation = getOrCreateDelegation(event.params.delegationID);
+  let validation = getOrCreateValidation(delegation.validationID);
+
+  delegation.unlocked = true;
+
+  // Only change BEAM weight here; keep ALL NFT behavior as-is elsewhere.
+  const isNFTDelegation =
+    delegation.tokenIDs != null && delegation.tokenIDs!.length > 0;
+
+  if (!isNFTDelegation) {
+    // BEAM claim → reduce validator.weight by EXACT delegation.weight
+    validation.weight = validation.weight.minus(delegation.weight);
+    validation.save();
+  }
+
+  delegation.save();
 }
 
 export function handleUnlockedValidation(event: UnlockedValidation): void {
-  let entity = getOrCreateValidation(event.params.validationID);
+  let validation = getOrCreateValidation(event.params.validationID);
 
-  entity.unlocked = true;
-  entity.save();
+  validation.unlocked = true;
+
+  // Only change BEAM weight here; DO NOT touch NFTs (keep original behavior).
+  // Reduce validator.weight by EXACT self-stake recorded at registration.
+  validation.weight = validation.weight.minus(validation.initialWeight);
+
+  validation.save();
 }
+
+// ----------------------
+// Reward claims snapshot
+// ----------------------
 
 export function handleRewardClaimed(event: RewardClaimed): void {
   let entity = getOrCreateClaimedReward(
@@ -320,7 +368,10 @@ export function handleRewardCancelled(event: RewardCancelled): void {
   entity.save();
 }
 
-// helper functions
+// ----------------------
+// helpers
+// ----------------------
+
 function getOrCreateValidation(id: Bytes): Validation {
   let entity = Validation.load(id);
   if (entity == null) {
@@ -349,6 +400,7 @@ function getOrCreateDelegation(id: Bytes): Delegation {
     entity.status = "Unknown";
     entity.unlocked = false;
     entity.lastRewardedEpoch = BigInt.zero();
+    // Note: keep tokenIDs uninitialized as in original (nullable) behavior
   }
   return entity;
 }

--- a/subgraphs/validator-manager/src/mapping.ts
+++ b/subgraphs/validator-manager/src/mapping.ts
@@ -226,6 +226,7 @@ export function handleUptimeUpdated(event: UptimeUpdated): void {
   entity.validationID = event.params.validationID;
   entity.uptimeSeconds = event.params.uptime;
   entity.epoch = event.params.epoch;
+
   entity.save();
 }
 
@@ -344,6 +345,7 @@ export function handleRewardCancelled(event: RewardCancelled): void {
   entity.save();
 }
 
+// helper functions
 function getOrCreateValidation(id: Bytes): Validation {
   let entity = Validation.load(id);
   if (entity == null) {

--- a/subgraphs/validator-manager/subgraph.yaml
+++ b/subgraphs/validator-manager/subgraph.yaml
@@ -8,11 +8,11 @@ indexerHints:
 dataSources:
   - kind: ethereum/contract
     name: ValidatorManager
-    network: beam-testnet
+    network: beam
     source:
       abi: ValidatorManager
-      address: "0x33B9785E20ec582d5009965FB3346F1716e8A423"
-      startBlock: 1186013
+      address: "0x46d5a1B62095cE9497C6Cc7Ab1BDb8a09D7e3c36"
+      startBlock: 3697229
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.7
@@ -40,11 +40,11 @@ dataSources:
       file: ./src/mapping.ts
   - kind: ethereum/contract
     name: Native721TokenStakingManager
-    network: beam-testnet
+    network: beam
     source:
       abi: Native721TokenStakingManager
-      address: "0xF4B5869AabE19a106C0df25E1537d855b54EEcBD"
-      startBlock: 1202461
+      address: "0x2FD428A5484d113294b44E69Cb9f269abC1d5B54"
+      startBlock: 3697236
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.7

--- a/subgraphs/validator-manager/subgraph.yaml
+++ b/subgraphs/validator-manager/subgraph.yaml
@@ -8,11 +8,11 @@ indexerHints:
 dataSources:
   - kind: ethereum/contract
     name: ValidatorManager
-    network: beam
+    network: beam-testnet
     source:
       abi: ValidatorManager
-      address: "0x46d5a1B62095cE9497C6Cc7Ab1BDb8a09D7e3c36"
-      startBlock: 3697229
+      address: "0x33B9785E20ec582d5009965FB3346F1716e8A423"
+      startBlock: 1186013
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.7
@@ -40,11 +40,11 @@ dataSources:
       file: ./src/mapping.ts
   - kind: ethereum/contract
     name: Native721TokenStakingManager
-    network: beam
+    network: beam-testnet
     source:
       abi: Native721TokenStakingManager
-      address: "0x2FD428A5484d113294b44E69Cb9f269abC1d5B54"
-      startBlock: 3697236
+      address: "0xF4B5869AabE19a106C0df25E1537d855b54EEcBD"
+      startBlock: 1202461
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.7


### PR DESCRIPTION
- `weight` field fixed: will now contain realtime info correlating $BEAM tokens locked
- `totalTokens` field fixed: shows only locked/unclaimed tokens