### PR TITLE
fix: set validation weight to zero when validator exits

### DIFF
--- a/subgraphs/validator-manager/src/mapping.ts
+++ b/subgraphs/validator-manager/src/mapping.ts
@@ -243,7 +243,7 @@ export function handleUnlockedDelegation(event: UnlockedDelegation): void {
   if (!delegation.unlocked) {
     const isNFT =
       delegation.tokenIDs != null && delegation.tokenIDs!.length > 0;
-    if (!isNFT) {
+    if (!isNFT && !validation.unlocked) {
       validation.weight = validation.weight.minus(delegation.weight);
       validation.save();
     }
@@ -262,7 +262,7 @@ export function handleUnlockedValidation(event: UnlockedValidation): void {
       );
     }
 
-    validation.weight = validation.weight.minus(validation.initialWeight);
+    validation.weight = BigInt.zero();
     validation.unlocked = true;
     validation.save();
     return;


### PR DESCRIPTION
I've tried it a couple ways around, and ended up with just a slight change to the existing logic to not muck things up.

This fix is built on the assumption that an exited validator's real stake weight is zero, so we set it to that when unlocking, and prevent further manipulation triggered by processed undelegations in unlocked state.

This is currently deployed to the _pos-beta_ and _pos-testnet-beta_ subgraphs. When testing via the [UI](https://graph.onbeam.com/subgraphs/name/pos-beta/graphql?query=query+validations+%7B%0A%09validations%28first%3A+1000%2C+where%3A+%7B%0A++++++++%23+nodeID_in%3A+%5B%2261a149683c8323aa4986cd511b428fb9f23f8159%22%2C%22904538c2e95a3e1bf8c206156ec6dee44ceaef78%22%5D%0A++++%09%09weight_lt%3A+0%0A++++%7D%2CorderBy%3A+startedAt%2C+orderDirection%3A+desc%29%7B%0A++++++++id%0A++++++++weight%0A++++++++initialWeight%0A++++++++owner%0A++++++++nodeID%0A++++++++status%0A++++++++tokenIDs%0A++++++++unlocked%0A++++++++totalTokens%0A++++++++delegationFeeBips%0A++++++++minStakeDuration%0A%09%7D+%0A%7D) I can't see any negative weights anymore, but the rest seems on par with the _pos_ subraph entries to me