### PR TITLE
fix: validation weight tracking

### DIFF
--- a/subgraphs/validator-manager/src/mapping.ts
+++ b/subgraphs/validator-manager/src/mapping.ts
@@ -130,11 +130,8 @@ export function handleCompletedValidatorWeightUpdate(
 ): void {
   let entity = getOrCreateValidation(event.params.validationID);
 
-  // Apply only increases now; defer decreases until unlock/claim.
-  if (event.params.weight.gt(entity.weight)) {
-    entity.weight = event.params.weight;
-    entity.save();
-  }
+  entity.weight = event.params.weight;
+  entity.save();
 }
 
 export function handleInitiatedDelegatorRegistration(
@@ -238,18 +235,9 @@ export function handleRewardResolved(event: RewardResolved): void {
 
 export function handleUnlockedDelegation(event: UnlockedDelegation): void {
   let delegation = getOrCreateDelegation(event.params.delegationID);
-  let validation = getOrCreateValidation(delegation.validationID);
 
-  if (!delegation.unlocked) {
-    const isNFT =
-      delegation.tokenIDs != null && delegation.tokenIDs!.length > 0;
-    if (!isNFT) {
-      validation.weight = validation.weight.minus(delegation.weight);
-      validation.save();
-    }
-    delegation.unlocked = true;
-    delegation.save();
-  }
+  delegation.unlocked = true;
+  delegation.save();
 }
 
 export function handleUnlockedValidation(event: UnlockedValidation): void {


### PR DESCRIPTION
Ok second attempt! I think the weight-update event is not emitted for exited validators, i've tried always syncing the weight with the event, and only subtracting the initial weight additionally when a validator exits.

This is currently deployed to the _pos-beta_ and _pos-testnet-beta_ subgraphs. When testing via the [UI](https://graph.onbeam.com/subgraphs/name/pos-beta/graphql?query=query+validations+%7B%0A%09validations%28first%3A+1000%2C+where%3A+%7B%0A++++++++%23+nodeID_in%3A+%5B%2261a149683c8323aa4986cd511b428fb9f23f8159%22%2C%22904538c2e95a3e1bf8c206156ec6dee44ceaef78%22%5D%0A++++%09%09weight_lt%3A+0%0A++++%7D%2CorderBy%3A+startedAt%2C+orderDirection%3A+desc%29%7B%0A++++++++id%0A++++++++weight%0A++++++++initialWeight%0A++++++++owner%0A++++++++nodeID%0A++++++++status%0A++++++++tokenIDs%0A++++++++unlocked%0A++++++++totalTokens%0A++++++++delegationFeeBips%0A++++++++minStakeDuration%0A%09%7D+%0A%7D) I can't see any negative weights anymore, but plenty with exactly 0 weight, which looks good to me.